### PR TITLE
Cloudflare tunnel setup

### DIFF
--- a/kubernetes/apps/network/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/configs/config.yaml
@@ -6,4 +6,8 @@ ingress:
   service: https://ingress-nginx-external-controller.network.svc.cluster.local:443
 - hostname: "*.${HOME_DOMAIN}"
   service: https://ingress-nginx-external-controller.network.svc.cluster.local:443
+- hostname: "hypermind.gg"
+  service: https://ingress-nginx-external-controller.network.svc.cluster.local:443
+- hostname: "*.hypermind.gg"
+  service: https://ingress-nginx-external-controller.network.svc.cluster.local:443
 - service: http_status:404

--- a/kubernetes/apps/network/cloudflared/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/cloudflared/app/dnsendpoint.yaml
@@ -8,3 +8,6 @@ spec:
   - dnsName: "external.${HOME_DOMAIN}"
     recordType: CNAME
     targets: ["${SECRET_CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com"]
+  - dnsName: "hypermind.gg"
+    recordType: CNAME
+    targets: ["${SECRET_CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com"]

--- a/kubernetes/apps/network/ingress-nginx/certificates/production.yaml
+++ b/kubernetes/apps/network/ingress-nginx/certificates/production.yaml
@@ -49,3 +49,19 @@ spec:
   dnsNames:
   - "${DEV_DOMAIN}"
   - "*.${DEV_DOMAIN}"
+# yamllint disable-line rule:document-start
+---
+# yaml-language-server: $schema=https://k8s-schemas.pages.dev/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hypermind-gg-production
+spec:
+  secretName: hypermind-gg-production-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "hypermind.gg"
+  dnsNames:
+  - "hypermind.gg"
+  - "*.hypermind.gg"

--- a/kubernetes/apps/services/hypermind/app/helmrelease.yaml
+++ b/kubernetes/apps/services/hypermind/app/helmrelease.yaml
@@ -84,3 +84,14 @@ spec:
             service:
               identifier: app
               port: http
+      external:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: external.${HOME_DOMAIN}
+        className: external
+        hosts:
+        - host: hypermind.gg
+          paths:
+          - path: /
+            service:
+              identifier: app
+              port: http


### PR DESCRIPTION
Add `hypermind.gg` domain configuration to route traffic through the Cloudflare tunnel to the hypermind service.

---
<a href="https://cursor.com/background-agent?bcId=bc-68c28305-ff56-46f5-ba2d-ae56171cbb25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68c28305-ff56-46f5-ba2d-ae56171cbb25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

