### PR TITLE
Hypermind daemonset deployment

### DIFF
--- a/kubernetes/apps/services/hypermind/app/helmrelease.yaml
+++ b/kubernetes/apps/services/hypermind/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
   values:
     controllers:
       hypermind:
-        replicas: 1
+        type: daemonset
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
Convert hypermind to a DaemonSet to ensure it runs on every node.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb1d2f70-2a73-46e5-b7a0-4c11f9c09e04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb1d2f70-2a73-46e5-b7a0-4c11f9c09e04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

