### PR TITLE
feat(bazarr): enable Authentik SSO forward authentication

### DIFF
--- a/kubernetes/apps/arrs/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/arrs/bazarr/app/helmrelease.yaml
@@ -97,6 +97,10 @@ spec:
       app:
         annotations:
           external-dns.alpha.kubernetes.io/target: internal.${HOME_DOMAIN}
+          nginx.ingress.kubernetes.io/auth-url: http://ak-outpost-authentik-embedded-outpost.security.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx
+          nginx.ingress.kubernetes.io/auth-signin: https://auth.${HOME_DOMAIN}/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri
+          nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid
+          nginx.ingress.kubernetes.io/auth-snippet: proxy_set_header X-Forwarded-Host $http_host;
         className: internal
         hosts:
         - host: "{{ .Release.Name }}.${HOME_DOMAIN}"


### PR DESCRIPTION
Add nginx ingress annotations to enable Authentik forward auth proxy,
allowing single sign-on for Bazarr through the embedded outpost.