### PR TITLE
fix(bazarr): add application parameter to Authentik forward auth URLs

### DIFF
--- a/kubernetes/apps/arrs/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/arrs/bazarr/app/helmrelease.yaml
@@ -97,8 +97,8 @@ spec:
       app:
         annotations:
           external-dns.alpha.kubernetes.io/target: internal.${HOME_DOMAIN}
-          nginx.ingress.kubernetes.io/auth-url: http://ak-outpost-authentik-embedded-outpost.security.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx
-          nginx.ingress.kubernetes.io/auth-signin: https://auth.${HOME_DOMAIN}/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri
+          nginx.ingress.kubernetes.io/auth-url: http://ak-outpost-authentik-embedded-outpost.security.svc.cluster.local:9000/outpost.goauthentik.io/auth/nginx?application=forward-auth
+          nginx.ingress.kubernetes.io/auth-signin: https://auth.${HOME_DOMAIN}/outpost.goauthentik.io/start?application=forward-auth&rd=$scheme://$host$request_uri
           nginx.ingress.kubernetes.io/auth-response-headers: Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid
           nginx.ingress.kubernetes.io/auth-snippet: proxy_set_header X-Forwarded-Host $http_host;
         className: internal


### PR DESCRIPTION
The auth-url and auth-signin annotations were missing the application
query parameter, which tells Authentik which forward auth provider to
use. Without this, Authentik doesn't know which application to
authenticate against and won't prompt for login.