### PR TITLE
[FLEET-11] Stage Zoo Fleet v0.2.0 deployment

### DIFF
--- a/kubernetes/apps/iot/zoo-fleet/README.md
+++ b/kubernetes/apps/iot/zoo-fleet/README.md
@@ -4,23 +4,17 @@ Zoo Fleet is the generic firmware control plane for The Zoo. It uses the shared
 PostgreSQL 17 service, Mosquitto at `mqtt.thezoo.house`, and the dedicated
 Unraid firmware release share.
 
-## Release-first deployment boundary
+## First deployment boundary
 
-The Flux Kustomization is intentionally suspended and the HelmRelease is kept
-as `app/helmrelease.release-required.yaml.tmpl`. The existing `v0.1.1` image
-does not contain the production startup work in FLEET-11, and no digest is
-fabricated here.
+The production-ready `v0.2.0` image is pinned by its exact multi-architecture
+digest in `app/helmrelease.yaml`. The Flux Kustomization remains suspended
+until the required `zoo-fleet` 1Password item exists and External Secrets can
+materialize every runtime value.
 
-To activate the first deployment:
-
-1. Merge and publish a new stable Zoo Fleet tag.
-2. Copy the exact multi-architecture image digest emitted by the release job.
-3. Copy `helmrelease.release-required.yaml.tmpl` to `helmrelease.yaml` and
-   replace `RELEASE_TAG@sha256:RELEASE_DIGEST` with that release tag and digest.
-4. Add `./helmrelease.yaml` to `app/kustomization.yaml`.
-5. Run `scripts/validate-app --offline iot/zoo-fleet` and
-   `scripts/check-image-pins kubernetes/apps/iot/zoo-fleet`.
-6. Remove `spec.suspend: true` from `ks.yaml` in the same reviewed change.
+To activate the first deployment, verify the required 1Password fields below,
+run `scripts/validate-app --offline iot/zoo-fleet` and
+`scripts/check-image-pins kubernetes/apps/iot/zoo-fleet`, then remove
+`spec.suspend: true` from `ks.yaml` in a reviewed change.
 
 The image runs database migrations under a PostgreSQL advisory lock before
 opening its HTTP listener. Missing migrations, an unavailable database, or

--- a/kubernetes/apps/iot/zoo-fleet/app/helmrelease.yaml
+++ b/kubernetes/apps/iot/zoo-fleet/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thezoo-house/zoo-fleet
-              tag: RELEASE_TAG@sha256:RELEASE_DIGEST
+              tag: 0.2.0@sha256:df6cb678f1a12e65eb2be342bb5b1b9a3be0b4bbd5778d04013fd100984871d5
             env:
               DATABASE_URL:
                 valueFrom:

--- a/kubernetes/apps/iot/zoo-fleet/app/kustomization.yaml
+++ b/kubernetes/apps/iot/zoo-fleet/app/kustomization.yaml
@@ -3,7 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ./externalsecret.yaml
+- ./helmrelease.yaml
 - ./ocirepository.yaml
 - ./storage.yaml
-# helmrelease.yaml is added here only after the release-first procedure in
-# ../README.md resolves an immutable Zoo Fleet image digest.

--- a/kubernetes/apps/iot/zoo-fleet/ks.yaml
+++ b/kubernetes/apps/iot/zoo-fleet/ks.yaml
@@ -5,8 +5,8 @@ metadata:
   name: &app zoo-fleet
   namespace: "${KS_NAMESPACE}"
 spec:
-  # FLEET-11 intentionally leaves this suspended until a release containing
-  # the production migration startup is published and pinned by digest.
+  # Zoo Fleet v0.2.0 is pinned, but first activation remains suspended until
+  # the required External Secrets source item exists.
   suspend: true
   targetNamespace: &namespace iot
   commonMetadata:


### PR DESCRIPTION
## Summary

- pin Zoo Fleet `0.2.0` to the immutable multi-architecture release digest
- promote the reviewed HelmRelease template into the rendered app resources
- keep Flux suspended until the required `zoo-fleet` External Secrets source item exists
- document the remaining first-activation boundary

## Verification

- `scripts/validate-app --offline iot/zoo-fleet`
- `scripts/check-image-pins kubernetes/apps/iot/zoo-fleet`
- `git diff --check`

## Deployment safety

This change does not deploy Zoo Fleet. `Kustomization/zoo-fleet` remains explicitly suspended.
