### PR TITLE
FLEET-11 Configure Talos private GHCR authentication

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,6 +1,11 @@
 creation_rules:
-- # IMPORTANT: This rule MUST be above the others
-  path_regex: talos/.*\.sops\.ya?ml
+# IMPORTANT: Keep specific Talos rules above the general Talos rule.
+- path_regex: talos/patches/global/ghcr-auth\.sops\.ya?ml
+  encrypted_regex: "^(username|password)$"
+  key_groups:
+  - age:
+    - "age1tk7tw0625mspavxe8lvv348p58ydqw6r04sxcjq76m98nan2lsnq3dhvxd"
+- path_regex: talos/.*\.sops\.ya?ml
   key_groups:
   - age:
     - "age1tk7tw0625mspavxe8lvv348p58ydqw6r04sxcjq76m98nan2lsnq3dhvxd"

--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -13,10 +13,25 @@ tasks:
       tmp="$(mktemp -d)"
       trap 'rm -rf "$tmp"' EXIT
 
-      talhelper validate talconfig "{{.TALOS_DIR}}/talconfig.yaml"
+      auth_patch="{{.TALOS_DIR}}/patches/global/ghcr-auth.sops.yaml"
+      grep -Eq '^username: ENC\[' "$auth_patch"
+      grep -Eq '^password: ENC\[' "$auth_patch"
+
+      mkdir -p "$tmp/talos"
+      cp "{{.TALOS_DIR}}/talconfig.yaml" "$tmp/talos/talconfig.yaml"
+      cp -R "{{.TALOS_DIR}}/patches" "$tmp/talos/patches"
+      cat > "$tmp/talos/patches/global/ghcr-auth.sops.yaml" <<'EOF'
+      apiVersion: v1alpha1
+      kind: RegistryAuthConfig
+      name: ghcr.io
+      username: ci-validation
+      password: ci-validation-placeholder
+      EOF
+
+      talhelper validate talconfig "$tmp/talos/talconfig.yaml"
       talhelper gensecret > "$tmp/talsecret.yaml"
       talhelper genconfig \
-        --config-file "{{.TALOS_DIR}}/talconfig.yaml" \
+        --config-file "$tmp/talos/talconfig.yaml" \
         --secret-file "$tmp/talsecret.yaml" \
         --out-dir "$tmp/clusterconfig" \
         --no-gitignore

--- a/talos/patches/global/ghcr-auth.sops.yaml
+++ b/talos/patches/global/ghcr-auth.sops.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1alpha1
+kind: RegistryAuthConfig
+name: ghcr.io
+username: ENC[AES256_GCM,data:CnpY5vjdHRIvtt8=,iv:NfqfKCpLI67FRxq04+jAmtujxeecKDgu08Av2hFhlHk=,tag:FMEhAa1bCTyPjumyZvFc0w==,type:str]
+password: ENC[AES256_GCM,data:2Sh7+5wetU+/BxT93R6hXEZJQGj6pgXANniEuX8rWkMOfbyvWH9FDQ==,iv:54JtJiE7rxIe3npuBX5LkV1hDiScM8EiOApDKYF3G2M=,tag:kDljldk3Zed4ajSuPQcbIw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwOXpkZ1FJVjZNN2NKZTlY
+            Yk1ka3MrUFlxbEwyV2lHTkdCQVVvblg2b25RCk1OdW9UaHJqdjNyUjhrZHZ1YWVX
+            MW4waGNuY0ZldTBtN2wwVXV4MjNoajQKLS0tIGVlT1hIVjRmOEtzYkJLaHN2Q1B1
+            UmhXOTg4ZlNwQ3oxRDNUZUlSYVFKcnMKusg7un482kq8emAs25sPM+TqgF3Q41p/
+            ItLrypAMfOdfwyQRNDuJ3AwxN05ErhJr0vii+q/nDZHcIwtB1wrH0Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1tk7tw0625mspavxe8lvv348p58ydqw6r04sxcjq76m98nan2lsnq3dhvxd
+    encrypted_regex: ^(username|password)$
+    lastmodified: "2026-07-29T02:12:51Z"
+    mac: ENC[AES256_GCM,data:iWqa+vKfwjVyVqQ1exacbAy5sdMLDwuB99WIU8ST2kSK5BPH8GULO8uCgRpN0pkEEQKTKZo0fZWVJLuxX6CI+1pkUmWiTAux5tg256G7ruJkZJmm1KAtuHgZptZP44938+BtlS09KTomlw4Hv4L31z46W24pWqBMNTnC/QzIqTM=,iv:HAVgvXPQKY4KUazXRe3D+IHDQLk3fqSiXlC7ueSFoaQ=,tag:rT1ngwA5v9Mpq2YlV4svIw==,type:str]
+    version: 3.13.1

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -111,6 +111,7 @@ patches:
 - "@./patches/global/containerd.yaml"
 - "@./patches/global/coredns.yaml"
 - "@./patches/global/dns-resolution.yaml"
+- "@./patches/global/ghcr-auth.sops.yaml"
 - "@./patches/global/kubelet.yaml"
 - "@./patches/global/nameserver.yaml"
 - "@./patches/global/nfs.yaml"


### PR DESCRIPTION
## Summary

- add a SOPS-encrypted `RegistryAuthConfig` for `ghcr.io`
- include it in the global Talos patch set for every node
- allow direct private image pulls without a reboot or CRI restart

## Validation

- rendered all five Talos machine configurations
- passed strict Talos 1.13.7 validation for every rendered config
- verified every rendered config contains non-empty GHCR auth fields without exposing credentials
- manually proved the same standalone config can pull the pinned Zoo Fleet v0.2.0 image on `k8s-chronos` with no reboot and no CRI restart