### PR TITLE
Deploy Zoo Fleet v0.2.6

### DIFF
--- a/kubernetes/apps/iot/zoo-fleet/README.md
+++ b/kubernetes/apps/iot/zoo-fleet/README.md
@@ -6,7 +6,7 @@ dedicated Unraid firmware release share.
 
 ## Deployment boundary
 
-The first-party `v0.2.5` Zoo Fleet chart and production image are both pinned
+The first-party `v0.2.6` Zoo Fleet chart and production image are both pinned
 by exact OCI digests. The Flux Kustomization is active and depends on External
 Secrets materializing every runtime value from the required `zoo-fleet`
 1Password item.

--- a/kubernetes/apps/iot/zoo-fleet/app/helmrelease.yaml
+++ b/kubernetes/apps/iot/zoo-fleet/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
     fullnameOverride: zoo-fleet
     image:
       repository: ghcr.io/thezoo-house/zoo-fleet
-      digest: sha256:6b1623fc9f7292399ca4a12ece771ff08d88fb26cc598c86c026331a4cec90ae
+      digest: sha256:449909b2c285b8e002bb59cd61e108b707509c12142133fc8c2171b2926fb205
     imagePullSecrets:
     - name: ghcr-pull-secret
     config:

--- a/kubernetes/apps/iot/zoo-fleet/app/ocirepository.yaml
+++ b/kubernetes/apps/iot/zoo-fleet/app/ocirepository.yaml
@@ -9,7 +9,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    digest: sha256:29eba0f70e04a2c4e9ff3bcb9a0691c6a1185557d0e097e90703a8da162a6789
+    digest: sha256:b2700547a3470e16eec17c8568262c6f40c26bac3c22aa9a5a79cd77d466fcc6
   secretRef:
     name: ghcr-pull-secret
   url: oci://ghcr.io/thezoo-house/charts/zoo-fleet


### PR DESCRIPTION
## Summary
- pin the Zoo Fleet v0.2.6 container by release digest
- pin the matching v0.2.6 OCI chart by release digest
- update the deployment documentation

This service release adds generic firmware scope registration. Firmware itself remains an explicit, separate publication operation.

## Verification
- `scripts/validate-app iot/zoo-fleet`