### PR TITLE
Deploy Zoo Fleet v0.2.8

### DIFF
--- a/kubernetes/apps/iot/zoo-fleet/README.md
+++ b/kubernetes/apps/iot/zoo-fleet/README.md
@@ -6,7 +6,7 @@ dedicated Unraid firmware release share.
 
 ## Deployment boundary
 
-The first-party `v0.2.7` Zoo Fleet chart and production image are both pinned
+The first-party `v0.2.8` Zoo Fleet chart and production image are both pinned
 by exact OCI digests. The Flux Kustomization is active and depends on External
 Secrets materializing every runtime value from the required `zoo-fleet`
 1Password item.

--- a/kubernetes/apps/iot/zoo-fleet/app/helmrelease.yaml
+++ b/kubernetes/apps/iot/zoo-fleet/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
     fullnameOverride: zoo-fleet
     image:
       repository: ghcr.io/thezoo-house/zoo-fleet
-      digest: sha256:a6154c49950d2a25ff3ab0911dc649d76e69b3c4c9123f311e7f2a9474c31ba1
+      digest: sha256:82d4361fcfa8df12c7f5bef38cff23f26e6aeb0212d450069bf1ad90c34092b3
     imagePullSecrets:
     - name: ghcr-pull-secret
     config:

--- a/kubernetes/apps/iot/zoo-fleet/app/ocirepository.yaml
+++ b/kubernetes/apps/iot/zoo-fleet/app/ocirepository.yaml
@@ -9,7 +9,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    digest: sha256:d75f04ebfbbaf5741be1d1487d00a2edf16eaf3b065c72d44be196bf23d67f85
+    digest: sha256:bf0ecf7f9b6ca71194a5fd55d43c2d14e2f35b66109843f7530c85bd627ce246
   secretRef:
     name: ghcr-pull-secret
   url: oci://ghcr.io/thezoo-house/charts/zoo-fleet


### PR DESCRIPTION
## Summary

- deploy Zoo Fleet 0.2.8 from its immutable OCI chart and image digests
- document the deployed control-plane version

## Validation

- kustomize render and Kubernetes server dry-run passed
- local validator reached Helm rendering, then hit the repository macOS Bash 3 empty-array bug (`value_args[@]: unbound variable`)
- release workflow published the referenced chart and image digests successfully

## Risk

- Risk level: Medium
- Rollback: revert the three digest/version pins to Zoo Fleet 0.2.7.
